### PR TITLE
Reformat src and text using php-cs-fixer and phpstorm

### DIFF
--- a/src/Builder.php
+++ b/src/Builder.php
@@ -2,10 +2,11 @@
 
 use Illuminate\Database\Eloquent\Builder as EloquentBuilder;
 
-class Builder extends EloquentBuilder {
+class Builder extends EloquentBuilder
+{
 
-    const COLUMN_MODEL_ID           = 'model_id';
-    const COLUMN_VERSION            = 'version';
+    const COLUMN_MODEL_ID = 'model_id';
+    const COLUMN_VERSION = 'version';
     const COLUMN_IS_CURRENT_VERSION = 'is_current_version';
 
     /**
@@ -37,10 +38,10 @@ class Builder extends EloquentBuilder {
     }
 
     /**
-     * A method to use with versioned scopes to retrieve a collection of non-current-version
-     * models (either with or without the current version)
+     * A method to use with versioned scopes to retrieve a collection of
+     * non-current-version models (either with or without the current version)
      *
-     * @param $id
+     * @param       $id
      * @param array $columns
      *
      * @return \Illuminate\Database\Eloquent\Collection
@@ -49,6 +50,4 @@ class Builder extends EloquentBuilder {
     {
         return $this->findMany([$id], $columns);
     }
-
-
 }

--- a/src/Scopes/VersioningScope.php
+++ b/src/Scopes/VersioningScope.php
@@ -1,78 +1,82 @@
 <?php namespace EloquentVersioned\Scopes;
 
-use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\ScopeInterface;
 
-class VersioningScope implements ScopeInterface {
+class VersioningScope implements ScopeInterface
+{
 
-	protected $extensions = [ 'WithOldVersions', 'OnlyOldVersions' ];
+    protected $extensions = ['WithOldVersions', 'OnlyOldVersions'];
 
-	public function apply( Builder $builder, Model $model ) {
-		$builder->where( $model->getQualifiedIsCurrentVersionColumn(), 1 );
+    public function apply(Builder $builder, Model $model)
+    {
+        $builder->where($model->getQualifiedIsCurrentVersionColumn(), 1);
 
-		$this->extend( $builder );
-	}
+        $this->extend($builder);
+    }
 
-	public function remove( Builder $builder, Model $model ) {
-		$column = $model->getQualifiedIsCurrentVersionColumn();
+    public function remove(Builder $builder, Model $model)
+    {
+        $column = $model->getQualifiedIsCurrentVersionColumn();
 
-		$query    = $builder->getQuery();
-		$bindings = $query->getBindings();
+        $query = $builder->getQuery();
+        $bindings = $query->getBindings();
 
-		$bindKey = 0;
+        $bindKey = 0;
 
-		foreach ( (array) $query->wheres as $key => $value ) {
+        foreach ((array)$query->wheres as $key => $value) {
+            if (strtolower($value['type']) == 'basic') {
+                $bindKey++;
+            }
+            if ($value['column'] == $column) {
+                if ($bindings[$bindKey - 1] == 1) {
+                    unset($bindings[$key]);
+                }
+                unset($query->wheres[$key]);
+            }
+        }
 
-			if ( strtolower( $value['type'] ) == 'basic' ) {
-				$bindKey ++;
-			}
-			if ( $value['column'] == $column ) {
-				if ( $bindings[ $bindKey - 1 ] == 1 ) {
-					unset( $bindings[ $key ] );
-				}
-				unset( $query->wheres[ $key ] );
-			}
-		}
+        $query->wheres = array_values($query->wheres);
 
-		$query->wheres = array_values( $query->wheres );
+        $builder->setBindings(array_values($bindings));
+    }
 
-		$builder->setBindings( array_values( $bindings ) );
+    /**
+     * @param Builder $builder
+     */
+    public function extend(Builder $builder)
+    {
+        foreach ($this->extensions as $extension) {
+            $this->{"add{$extension}"}($builder);
+        }
+    }
 
-	}
+    /**
+     * @param Builder $builder
+     */
+    protected function addWithOldVersions(Builder $builder)
+    {
+        $builder->macro('withOldVersions', function (Builder $builder) {
+            $this->remove($builder, $builder->getModel());
 
-	/**
-	 * @param Builder $builder
-	 */
-	public function extend( Builder $builder ) {
-		foreach ( $this->extensions as $extension ) {
-			$this->{"add{$extension}"}( $builder );
-		}
-	}
+            return $builder;
+        });
+    }
 
-	/**
-	 * @param Builder $builder
-	 */
-	protected function addWithOldVersions( Builder $builder ) {
-		$builder->macro( 'withOldVersions', function ( Builder $builder ) {
-			$this->remove( $builder, $builder->getModel() );
+    /**
+     * @param Builder $builder
+     */
+    protected function addOnlyOldVersions(Builder $builder)
+    {
+        $builder->macro('onlyOldVersions', function (Builder $builder) {
+            $model = $builder->getModel();
+            $this->remove($builder, $model);
 
-			return $builder;
-		} );
-	}
+            $builder->getQuery()->where($model->getQualifiedIsCurrentVersionColumn(),
+                0);
 
-	/**
-	 * @param Builder $builder
-	 */
-	protected function addOnlyOldVersions( Builder $builder ) {
-		$builder->macro( 'onlyOldVersions', function ( Builder $builder ) {
-			$model = $builder->getModel();
-			$this->remove( $builder, $model );
-
-			$builder->getQuery()->where( $model->getQualifiedIsCurrentVersionColumn(), 0 );
-
-			return $builder;
-		} );
-	}
-
+            return $builder;
+        });
+    }
 }

--- a/src/Traits/Versioned.php
+++ b/src/Traits/Versioned.php
@@ -1,310 +1,337 @@
 <?php namespace EloquentVersioned\Traits;
 
-use Illuminate\Database\Eloquent\Builder;
-use EloquentVersioned\Scopes\VersioningScope;
 use EloquentVersioned\Builder as VersionedBuilder;
-
-trait Versioned {
-
-	protected $isVersioned = true;
-
-	protected $hideVersioned = [ VersionedBuilder::COLUMN_IS_CURRENT_VERSION, VersionedBuilder::COLUMN_MODEL_ID ];
-
-	public static function bootVersioned() {
-		static::addGlobalScope( new VersioningScope() );
-	}
-
-	protected function getHideVersioned( $hide = array() ) {
-		return array_merge( $hide, $this->hideVersioned );
-	}
-
-	/*
-	 * ACCESSORS + MUTATORS
-	 */
-
-	/**
-	 * @return mixed
-	 */
-	public function getIdAttribute() {
-		return ( $this->{static::getIsCurrentVersionColumn()} == 0 ) ? $this->attributes[ $this->primaryKey ] : $this->attributes[ static::getModelIdColumn() ];
-	}
-
-	/*
-	 * ELOQUENT OVERRIDES
-	 */
-
-	/**
-	 * @return string
-	 */
-	public function getKeyName() {
-		return $this->isVersioned ? $this->getModelIdColumn() : $this->primaryKey;
-	}
-
-	/**
-	 * @param $query
-	 *
-	 * @return VersionedBuilder
-	 */
-	public function newEloquentBuilder( $query ) {
-		return new VersionedBuilder( $query );
-	}
-
-	/**
-	 * @return array
-	 */
-	public function attributesToArray( $hide = array() ) {
-		$parentAttributes = parent::attributesToArray();
-
-		if ( ( ! $this->isVersioned ) || ( $this->{static::getIsCurrentVersionColumn()} == 0 ) ) {
-			return $parentAttributes;
-		}
-
-		$attributes = [ ];
-		foreach ( $parentAttributes as $key => $value ) {
-			if ( ! in_array( $key, $this->getHideVersioned( $hide ) ) ) {
-				$attributes[ $key ] = $value;
-			}
-		}
-
-		return $attributes;
-	}
-
-	/**
-	 * @param Builder $query
-	 *
-	 * @return Builder
-	 */
-	protected function setKeysForSaveQuery( Builder $query ) {
-		$query->where( $this->getKeyName(), '=', $this->getKeyForSaveQuery() )
-		      ->where( $this->getQualifiedIsCurrentVersionColumn(), 1 );
-
-		return $query;
-	}
-
-	/**
-	 * @param array $options
-	 *
-	 * @return mixed
-	 */
-	public function saveMinor( array $options = array() ) {
-		return parent::save( $options );
-	}
-
-	/**
-	 * @param array $options
-	 *
-	 * @return bool
-	 */
-	public function save( array $options = array() ) {
-		$query = $this->newQueryWithoutScopes();
-
-		$db = $this->getConnection();
-
-		// If the "saving" event returns false we'll bail out of the save and return
-		// false, indicating that the save failed. This provides a chance for any
-		// listeners to cancel save operations if validations fail or whatever.
-		if ( $this->fireModelEvent( 'saving' ) === false ) {
-			return false;
-		}
-
-		// If the model already exists in the database we can just update our record
-		// that is already in this database using the current IDs in this "where"
-		// clause to only update this model. Otherwise, we'll just insert them.
-		if ( $this->exists ) {
-
-			$dirty = $this->getDirty();
-
-			if ( count( $dirty ) > 0 ) {
-
-				$saved = $db->transaction( function () use ( $query, $db ) {
-
-					$newVersion                                        = $this->replicate( [
-						$this->primaryKey,
-						static::getVersionColumn(),
-						'updated_at'
-					] );
-					$newVersion->{static::getVersionColumn()}          = static::getNextVersion( $this->{static::getModelIdColumn()} );
-					$newVersion->{static::getIsCurrentVersionColumn()} = 1;
-					$newVersion->updated_at                            = $this->freshTimestamp();
-
-					// trigger the update event
-					if ( $this->fireModelEvent( 'updating' ) === false ) {
-						return false;
-					}
-
-					// clear out the old stuff
-					unset( $this->attributes[ $this->primaryKey ] );
-					unset( $this->attributes['updated_at'] );
-
-					$this->forceFill( $newVersion->getAttributes() );
-
-					$saved = $this->performVersionedInsert( $query, [ 'timestamps' => false ] );
-
-					if ( $saved ) {
-
-						// toggle the is_current_version flag
-						$db->table( ( new static )->getTable() )
-						   ->where( static::getModelIdColumn(), $this->{static::getModelIdColumn()} )
-						   ->where( static::getIsCurrentVersionColumn(), 1 )
-						   ->where( $this->primaryKey, '<>', $this->attributes[ $this->primaryKey ] )
-						   ->update( [ static::getIsCurrentVersionColumn() => 0 ] );
-
-						$this->fireModelEvent( 'updated', false );
-
-					}
-
-					return $saved;
-
-				} );
-			} else {
-				$saved = true;
-			}
-		}
-
-		// If the model is brand new, we'll insert it into our database and set the
-		// ID attribute on the model to the value of the newly inserted row's ID
-		// which is typically an auto-increment value managed by the database.
-		else {
-			$this->{static::getModelIdColumn()} = static::getNextModelId();
-			$saved                              = $this->performInsert( $query, $options );
-		}
-
-		if ( $saved ) {
-			$this->finishSave( $options );
-		}
-
-		return $saved;
-	}
-
-	protected function insertAndSetId( Builder $query, $attributes ) {
-		$id = $query->insertGetId( $attributes, $keyName = $this->primaryKey );
-
-		$this->setAttribute( $keyName, $id );
-	}
-
-	/*
-	 * EXTENSIONS
-	 */
-
-	protected function performVersionedInsert( Builder $query, array $options = array() ) {
-		// First we'll need to create a fresh query instance and touch the creation and
-		// update timestamps on this model, which are maintained by us for developer
-		// convenience. After, we will just continue saving these model instances.
-		if ( $this->timestamps && array_get( $options, 'timestamps', true ) ) {
-			$this->updateTimestamps();
-		}
-
-		// If the model has an incrementing key, we can use the "insertGetId" method on
-		// the query builder, which will give us back the final inserted ID for this
-		// table from the database. Not all tables have to be incrementing though.
-		$attributes = $this->attributes;
-
-		if ( $this->incrementing ) {
-			$this->insertAndSetId( $query, $attributes );
-		}
-
-		// If the table is not incrementing we'll simply insert this attributes as they
-		// are, as this attributes arrays must contain an "id" column already placed
-		// there by the developer as the manually determined key for these models.
-		else {
-			$query->insert( $attributes );
-		}
-
-		// We will go ahead and set the exists property to true, so that it is set when
-		// the created event is fired, just in case the developer tries to update it
-		// during the event. This will allow them to do so and run an update here.
-		$this->exists = true;
-
-		return true;
-
-	}
-
-	/**
-	 * @param bool $isVersioned
-	 *
-	 * @return $this
-	 */
-	public function setIsVersioned( $isVersioned = true ) {
-		$this->isVersioned = $isVersioned;
-
-		return $this;
-	}
-
-	/**
-	 * @return mixed
-	 */
-	public static function getNextModelId() {
-		return ( new static )->getConnection()->table( ( new static )->getTable() )->max( static::getModelIdColumn() ) + 1;
-	}
-
-	/**
-	 * @param int $modelId
-	 *
-	 * @return int
-	 */
-	public static function getNextVersion( $modelId ) {
-		return ( new static )->getConnection()->table( ( new static )->getTable() )->where( static::getModelIdColumn(), $modelId )->max( static::getVersionColumn() ) + 1;
-	}
-
-	/**
-	 * @return string
-	 */
-	public static function getModelIdColumn() {
-		return VersionedBuilder::COLUMN_MODEL_ID;
-
-	}
-
-	/**
-	 * @return string
-	 */
-	public static function getQualifiedModelIdColumn() {
-		return ( new static )->getTable() . '.' . static::getModelIdColumn();
-	}
-
-	/**
-	 * @return string
-	 */
-	public static function getVersionColumn() {
-		return VersionedBuilder::COLUMN_VERSION;
-
-	}
-
-	/**
-	 * @return string
-	 */
-	public static function getQualifiedVersionColumn() {
-		return ( new static )->getTable() . '.' . static::getVersionColumn();
-	}
-
-	/**
-	 * @return string
-	 */
-	public static function getIsCurrentVersionColumn() {
-		return VersionedBuilder::COLUMN_IS_CURRENT_VERSION;
-
-	}
-
-	/**
-	 * @return string
-	 */
-	public static function getQualifiedIsCurrentVersionColumn() {
-		return ( new static )->getTable() . '.' . static::getIsCurrentVersionColumn();
-	}
-
-	/**
-	 * @return mixed
-	 */
-	public static function withOldVersions() {
-		return ( new static )->newQueryWithoutScope( new VersioningScope );
-	}
-
-	/**
-	 * @return mixed
-	 */
-	public static function onlyOldVersions() {
-
-		return ( new static )->newQueryWithoutScope( new VersioningScope )->where( static::getQualifiedIsCurrentVersionColumn(), 0 );
-
-	}
-
+use EloquentVersioned\Scopes\VersioningScope;
+use Illuminate\Database\Eloquent\Builder;
+
+trait Versioned
+{
+
+    protected $isVersioned = true;
+
+    protected $hideVersioned = [
+        VersionedBuilder::COLUMN_IS_CURRENT_VERSION,
+        VersionedBuilder::COLUMN_MODEL_ID
+    ];
+
+    public static function bootVersioned()
+    {
+        static::addGlobalScope(new VersioningScope());
+    }
+
+    protected function getHideVersioned($hide = array())
+    {
+        return array_merge($hide, $this->hideVersioned);
+    }
+
+    /*
+     * ACCESSORS + MUTATORS
+     */
+
+    /**
+     * @return mixed
+     */
+    public function getIdAttribute()
+    {
+        return ($this->{static::getIsCurrentVersionColumn()} == 0) ?
+            $this->attributes[$this->primaryKey] :
+            $this->attributes[static::getModelIdColumn()];
+    }
+
+    /*
+     * ELOQUENT OVERRIDES
+     */
+
+    /**
+     * @return string
+     */
+    public function getKeyName()
+    {
+        return $this->isVersioned ? $this->getModelIdColumn() : $this->primaryKey;
+    }
+
+    /**
+     * @param $query
+     *
+     * @return VersionedBuilder
+     */
+    public function newEloquentBuilder($query)
+    {
+        return new VersionedBuilder($query);
+    }
+
+    /**
+     * @return array
+     */
+    public function attributesToArray($hide = array())
+    {
+        $parentAttributes = parent::attributesToArray();
+
+        if ((!$this->isVersioned) || ($this->{static::getIsCurrentVersionColumn()} == 0)) {
+            return $parentAttributes;
+        }
+
+        $attributes = [];
+        foreach ($parentAttributes as $key => $value) {
+            if (!in_array($key, $this->getHideVersioned($hide))) {
+                $attributes[$key] = $value;
+            }
+        }
+
+        return $attributes;
+    }
+
+    /**
+     * @param Builder $query
+     *
+     * @return Builder
+     */
+    protected function setKeysForSaveQuery(Builder $query)
+    {
+        $query->where($this->getKeyName(), '=', $this->getKeyForSaveQuery())
+            ->where($this->getQualifiedIsCurrentVersionColumn(), 1);
+
+        return $query;
+    }
+
+    /**
+     * @param array $options
+     *
+     * @return mixed
+     */
+    public function saveMinor(array $options = array())
+    {
+        return parent::save($options);
+    }
+
+    /**
+     * @param array $options
+     *
+     * @return bool
+     */
+    public function save(array $options = array())
+    {
+        $query = $this->newQueryWithoutScopes();
+
+        $db = $this->getConnection();
+
+        // If the "saving" event returns false we'll bail out of the save and return
+        // false, indicating that the save failed. This provides a chance for any
+        // listeners to cancel save operations if validations fail or whatever.
+        if ($this->fireModelEvent('saving') === false) {
+            return false;
+        }
+
+        // If the model already exists in the database we can just update our record
+        // that is already in this database using the current IDs in this "where"
+        // clause to only update this model. Otherwise, we'll just insert them.
+        if ($this->exists) {
+            $dirty = $this->getDirty();
+
+            if (count($dirty) > 0) {
+                $saved = $db->transaction(function () use ($query, $db) {
+
+                    $newVersion = $this->replicate([
+                        $this->primaryKey,
+                        static::getVersionColumn(),
+                        'updated_at'
+                    ]);
+                    $newVersion->{static::getVersionColumn()} = static::getNextVersion($this->{static::getModelIdColumn()});
+                    $newVersion->{static::getIsCurrentVersionColumn()} = 1;
+                    $newVersion->updated_at = $this->freshTimestamp();
+
+                    // trigger the update event
+                    if ($this->fireModelEvent('updating') === false) {
+                        return false;
+                    }
+
+                    // clear out the old stuff
+                    unset($this->attributes[$this->primaryKey]);
+                    unset($this->attributes['updated_at']);
+
+                    $this->forceFill($newVersion->getAttributes());
+
+                    $saved = $this->performVersionedInsert($query,
+                        ['timestamps' => false]);
+
+                    if ($saved) {
+
+                        // toggle the is_current_version flag
+                        $db->table((new static)->getTable())
+                            ->where(static::getModelIdColumn(),
+                                $this->{static::getModelIdColumn()})
+                            ->where(static::getIsCurrentVersionColumn(), 1)
+                            ->where($this->primaryKey, '<>',
+                                $this->attributes[$this->primaryKey])
+                            ->update([static::getIsCurrentVersionColumn() => 0]);
+
+                        $this->fireModelEvent('updated', false);
+                    }
+
+                    return $saved;
+
+                });
+            } else {
+                $saved = true;
+            }
+        }
+
+        // If the model is brand new, we'll insert it into our database and set the
+        // ID attribute on the model to the value of the newly inserted row's ID
+        // which is typically an auto-increment value managed by the database.
+        else {
+            $this->{static::getModelIdColumn()} = static::getNextModelId();
+            $saved = $this->performInsert($query, $options);
+        }
+
+        if ($saved) {
+            $this->finishSave($options);
+        }
+
+        return $saved;
+    }
+
+    protected function insertAndSetId(Builder $query, $attributes)
+    {
+        $id = $query->insertGetId($attributes, $keyName = $this->primaryKey);
+
+        $this->setAttribute($keyName, $id);
+    }
+
+    /*
+     * EXTENSIONS
+     */
+
+    protected function performVersionedInsert(
+        Builder $query,
+        array $options = array()
+    ) {
+        // First we'll need to create a fresh query instance and touch the creation and
+        // update timestamps on this model, which are maintained by us for developer
+        // convenience. After, we will just continue saving these model instances.
+        if ($this->timestamps && array_get($options, 'timestamps', true)) {
+            $this->updateTimestamps();
+        }
+
+        // If the model has an incrementing key, we can use the "insertGetId" method on
+        // the query builder, which will give us back the final inserted ID for this
+        // table from the database. Not all tables have to be incrementing though.
+        $attributes = $this->attributes;
+
+        if ($this->incrementing) {
+            $this->insertAndSetId($query, $attributes);
+        }
+
+        // If the table is not incrementing we'll simply insert this attributes as they
+        // are, as this attributes arrays must contain an "id" column already placed
+        // there by the developer as the manually determined key for these models.
+        else {
+            $query->insert($attributes);
+        }
+
+        // We will go ahead and set the exists property to true, so that it is set when
+        // the created event is fired, just in case the developer tries to update it
+        // during the event. This will allow them to do so and run an update here.
+        $this->exists = true;
+
+        return true;
+    }
+
+    /**
+     * @param bool $isVersioned
+     *
+     * @return $this
+     */
+    public function setIsVersioned($isVersioned = true)
+    {
+        $this->isVersioned = $isVersioned;
+
+        return $this;
+    }
+
+    /**
+     * @return mixed
+     */
+    public static function getNextModelId()
+    {
+        return (new static)->getConnection()->table((new static)->getTable())
+            ->max(static::getModelIdColumn()) + 1;
+    }
+
+    /**
+     * @param int $modelId
+     *
+     * @return int
+     */
+    public static function getNextVersion($modelId)
+    {
+        return (new static)->getConnection()->table((new static)->getTable())
+            ->where(static::getModelIdColumn(), $modelId)
+            ->max(static::getVersionColumn()) + 1;
+    }
+
+    /**
+     * @return string
+     */
+    public static function getModelIdColumn()
+    {
+        return VersionedBuilder::COLUMN_MODEL_ID;
+    }
+
+    /**
+     * @return string
+     */
+    public static function getQualifiedModelIdColumn()
+    {
+        return (new static)->getTable() . '.' . static::getModelIdColumn();
+    }
+
+    /**
+     * @return string
+     */
+    public static function getVersionColumn()
+    {
+        return VersionedBuilder::COLUMN_VERSION;
+    }
+
+    /**
+     * @return string
+     */
+    public static function getQualifiedVersionColumn()
+    {
+        return (new static)->getTable() . '.' . static::getVersionColumn();
+    }
+
+    /**
+     * @return string
+     */
+    public static function getIsCurrentVersionColumn()
+    {
+        return VersionedBuilder::COLUMN_IS_CURRENT_VERSION;
+    }
+
+    /**
+     * @return string
+     */
+    public static function getQualifiedIsCurrentVersionColumn()
+    {
+        return (new static)->getTable() . '.' . static::getIsCurrentVersionColumn();
+    }
+
+    /**
+     * @return mixed
+     */
+    public static function withOldVersions()
+    {
+        return (new static)->newQueryWithoutScope(new VersioningScope);
+    }
+
+    /**
+     * @return mixed
+     */
+    public static function onlyOldVersions()
+    {
+        return (new static)->newQueryWithoutScope(new VersioningScope)
+            ->where(static::getQualifiedIsCurrentVersionColumn(), 0);
+    }
 }

--- a/tests/FunctionalTestCase.php
+++ b/tests/FunctionalTestCase.php
@@ -15,11 +15,11 @@ class FunctionalTestCase extends \PHPUnit_Framework_TestCase
     {
         $db = new DBM;
         $db->addConnection(array(
-            'driver'    => 'sqlite',
-            'database'  => ':memory:',
-            'charset'   => 'utf8',
+            'driver' => 'sqlite',
+            'database' => ':memory:',
+            'charset' => 'utf8',
             'collation' => 'utf8_unicode_ci',
-            'prefix'    => '',
+            'prefix' => '',
         ));
         $db->bootEloquent();
         $db->setAsGlobal();
@@ -27,8 +27,7 @@ class FunctionalTestCase extends \PHPUnit_Framework_TestCase
 
     protected function migrateTables()
     {
-
-        DBM::schema()->create('widgets', function($table) {
+        DBM::schema()->create('widgets', function ($table) {
             $table->increments('id');
             $table->integer('model_id')->unsigned()->default(1);
             $table->integer('version')->unsigned()->default(1);
@@ -39,7 +38,7 @@ class FunctionalTestCase extends \PHPUnit_Framework_TestCase
             $table->timestamps();
         });
 
-        DBM::schema()->create('gadgets', function($table) {
+        DBM::schema()->create('gadgets', function ($table) {
             $table->increments('id');
             $table->integer('model_id')->unsigned()->default(1);
             $table->integer('version')->unsigned()->default(1);
@@ -50,7 +49,7 @@ class FunctionalTestCase extends \PHPUnit_Framework_TestCase
             $table->timestamps();
         });
 
-        DBM::schema()->create('doodads', function($table) {
+        DBM::schema()->create('doodads', function ($table) {
             $table->increments('id');
             $table->integer('model_id')->unsigned()->default(1);
             $table->integer('version')->unsigned()->default(1);
@@ -60,7 +59,5 @@ class FunctionalTestCase extends \PHPUnit_Framework_TestCase
             $table->string('name');
             $table->timestamps();
         });
-
     }
-
 }

--- a/tests/Models/BaseVersionedModel.php
+++ b/tests/Models/BaseVersionedModel.php
@@ -6,5 +6,4 @@ use EloquentVersioned\Traits\Versioned;
 class BaseVersionedModel extends Eloquent
 {
     use Versioned;
-
 }

--- a/tests/Models/Doodad.php
+++ b/tests/Models/Doodad.php
@@ -1,6 +1,7 @@
 <?php namespace EloquentVersioned\Tests\Models;
 
-class Doodad extends BaseVersionedModel {
+class Doodad extends BaseVersionedModel
+{
 
     protected $table = 'doodads';
 
@@ -8,12 +9,13 @@ class Doodad extends BaseVersionedModel {
 
     public function gadget()
     {
-        return $this->belongsTo('EloquentVersioned\Tests\Models\Gadget', 'gadget_id');
+        return $this->belongsTo('EloquentVersioned\Tests\Models\Gadget',
+            'gadget_id');
     }
 
     public function widget()
     {
-        return $this->belongsTo('EloquentVersioned\Tests\Models\Widget', 'widget_id');
+        return $this->belongsTo('EloquentVersioned\Tests\Models\Widget',
+            'widget_id');
     }
-
 }

--- a/tests/Models/Gadget.php
+++ b/tests/Models/Gadget.php
@@ -1,6 +1,7 @@
 <?php namespace EloquentVersioned\Tests\Models;
 
-class Gadget extends BaseVersionedModel {
+class Gadget extends BaseVersionedModel
+{
 
     protected $table = 'gadgets';
 
@@ -8,12 +9,13 @@ class Gadget extends BaseVersionedModel {
 
     public function widget()
     {
-        return $this->belongsTo('EloquentVersioned\Tests\Models\Widget', 'widget_id');
+        return $this->belongsTo('EloquentVersioned\Tests\Models\Widget',
+            'widget_id');
     }
 
     public function doodad()
     {
-        return $this->belongsTo('EloquentVersioned\Tests\Models\Doodad', 'doodad_id');
+        return $this->belongsTo('EloquentVersioned\Tests\Models\Doodad',
+            'doodad_id');
     }
-
 }

--- a/tests/Models/Widget.php
+++ b/tests/Models/Widget.php
@@ -1,6 +1,7 @@
 <?php namespace EloquentVersioned\Tests\Models;
 
-class Widget extends BaseVersionedModel {
+class Widget extends BaseVersionedModel
+{
 
     protected $table = 'widgets';
 
@@ -8,12 +9,13 @@ class Widget extends BaseVersionedModel {
 
     public function gadget()
     {
-        return $this->belongsTo('EloquentVersioned\Tests\Models\Gadget', 'gadget_id');
+        return $this->belongsTo('EloquentVersioned\Tests\Models\Gadget',
+            'gadget_id');
     }
 
     public function doodad()
     {
-        return $this->belongsTo('EloquentVersioned\Tests\Models\Doodad', 'doodad_id');
+        return $this->belongsTo('EloquentVersioned\Tests\Models\Doodad',
+            'doodad_id');
     }
-
 }

--- a/tests/VersionedTest.php
+++ b/tests/VersionedTest.php
@@ -2,104 +2,121 @@
 
 use Illuminate\Database\Eloquent\Model as Eloquent;
 
-class VersionedTest extends FunctionalTestCase {
+class VersionedTest extends FunctionalTestCase
+{
 
-	protected $modelPrefix = "\\EloquentVersioned\\Tests\\Models\\";
+    protected $modelPrefix = "\\EloquentVersioned\\Tests\\Models\\";
 
-	public function setUp() {
-		parent::setUp();
-		Eloquent::unguard();
-	}
+    public function setUp()
+    {
+        parent::setUp();
+        Eloquent::unguard();
+    }
 
-	/**
-	 * We should be able to create a model
-	 *
-	 * @param  array $data
-	 * @dataProvider createDataProvider
-	 */
-	public function testCreate( $data ) {
-		$className = $this->modelPrefix . $data['name'];
-		$model     = $className::create( $data )->fresh();
+    /**
+     * We should be able to create a model
+     *
+     * @param  array $data
+     *
+     * @dataProvider createDataProvider
+     */
+    public function testCreate($data)
+    {
+        $className = $this->modelPrefix . $data['name'];
+        $model = $className::create($data)->fresh();
 
-		// model exists?
-		$this->assertInstanceOf( $this->modelPrefix . $data['name'], $model );
-		$this->assertEquals( 1, $model->id );
-		$this->assertEquals( 1, $model->version );
-		$this->assertEquals( 1, $model->is_current_version );
+        // model exists?
+        $this->assertInstanceOf($this->modelPrefix . $data['name'], $model);
+        $this->assertEquals(1, $model->id);
+        $this->assertEquals(1, $model->version);
+        $this->assertEquals(1, $model->is_current_version);
+    }
 
-	}
+    /**
+     * Using save() should create a new version
+     *
+     * @param  array $data
+     *
+     * @dataProvider createDataProvider
+     */
+    public function testSave($data)
+    {
+        $className = $this->modelPrefix . $data['name'];
+        $model = $className::create($data)->fresh();
 
-	/**
-	 * Using save() should create a new version
-	 *
-	 * @param  array $data
-	 * @dataProvider createDataProvider
-	 */
-	public function testSave( $data ) {
-		$className = $this->modelPrefix . $data['name'];
-		$model     = $className::create( $data )->fresh();
+        $model->name = 'Updated ' . $data['name'];
+        $model->save();
 
-		$model->name = 'Updated ' . $data['name'];
-		$model->save();
+        // model was updated correctly?
+        $this->assertEquals(1, $model->id);
+        $this->assertEquals('Updated ' . $data['name'], $model->name);
+        $this->assertEquals(2, $model->version);
+        $this->assertEquals(1, $model->is_current_version);
 
-		// model was updated correctly?
-		$this->assertEquals( 1, $model->id );
-		$this->assertEquals( 'Updated ' . $data['name'], $model->name );
-		$this->assertEquals( 2, $model->version );
-		$this->assertEquals( 1, $model->is_current_version );
+        // old model exists?
+        $oldModel = $className::onlyOldVersions()->find(1);
+        $this->assertInstanceOf($this->modelPrefix . $data['name'], $oldModel);
+        $this->assertEquals(1, $oldModel->version);
+        $this->assertEquals(0, $oldModel->is_current_version);
 
-		// old model exists?
-		$oldModel = $className::onlyOldVersions()->find( 1 );
-		$this->assertInstanceOf( $this->modelPrefix . $data['name'], $oldModel );
-		$this->assertEquals( 1, $oldModel->version );
-		$this->assertEquals( 0, $oldModel->is_current_version );
+        // one record with scopes applied?
+        $models = $className::all();
+        $this->assertEquals(1, count($models));
 
-		// one record with scopes applied?
-		$models = $className::all();
-		$this->assertEquals( 1, count( $models ) );
+        // two records without scopes applied?
+        $models = $className::withOldVersions()->get();
+        $this->assertEquals(2, count($models));
+    }
 
-		// two records without scopes applied?
-		$models = $className::withOldVersions()->get();
-		$this->assertEquals( 2, count( $models ) );
+    /**
+     * Using saveMinor() should not create a new version
+     *
+     * @param  array $data
+     *
+     * @dataProvider createDataProvider
+     */
+    public function testMinorSave($data)
+    {
+        $className = $this->modelPrefix . $data['name'];
+        $model = $className::create($data)->fresh();
 
-	}
+        $model->name = 'Updated ' . $data['name'];
+        $model->saveMinor();
 
-	/**
-	 * Using saveMinor() should not create a new version
-	 *
-	 * @param  array $data
-	 * @dataProvider createDataProvider
-	 */
-	public function testMinorSave( $data ) {
-		$className = $this->modelPrefix . $data['name'];
-		$model     = $className::create( $data )->fresh();
+        // model was updated correctly?
+        $this->assertEquals(1, $model->id);
+        $this->assertEquals('Updated ' . $data['name'], $model->name);
+        $this->assertEquals(1, $model->version);
+        $this->assertEquals(1, $model->is_current_version);
 
-		$model->name = 'Updated ' . $data['name'];
-		$model->saveMinor();
+        // still only one record?
+        $models = $className::all();
+        $this->assertEquals(1, count($models));
+    }
 
-		// model was updated correctly?
-		$this->assertEquals( 1, $model->id );
-		$this->assertEquals( 'Updated ' . $data['name'], $model->name );
-		$this->assertEquals( 1, $model->version );
-		$this->assertEquals( 1, $model->is_current_version );
-
-		// still only one record?
-		$models = $className::all();
-		$this->assertEquals( 1, count( $models ) );
-
-	}
-
-	/**
-	 * Provides objects to use by tests
-	 *
-	 * @return array
-	 */
-	public function createDataProvider() {
-		return array(
-			array( array( 'name' => 'Widget', 'gadget_id' => 1, 'doodad_id' => 1 ) ),
-			array( array( 'name' => 'Gadget', 'widget_id' => 1, 'doodad_id' => 1 ) ),
-			array( array( 'name' => 'Doodad', 'widget_id' => 1, 'gadget_id' => 1 ) )
-		);
-	}
-
+    /**
+     * Provides objects to use by tests
+     *
+     * @return array
+     */
+    public function createDataProvider()
+    {
+        return array(
+            array(
+                array(
+                    'name' => 'Widget',
+                    'gadget_id' => 1,
+                    'doodad_id' => 1
+                )
+            ),
+            array(
+                array(
+                    'name' => 'Gadget',
+                    'widget_id' => 1,
+                    'doodad_id' => 1
+                )
+            ),
+            array(array('name' => 'Doodad', 'widget_id' => 1, 'gadget_id' => 1))
+        );
+    }
 }


### PR DESCRIPTION
I've just run 'php-cs-fixer fix --level=psr2' on the src and test
folders and then also used PHPStorms built in reformatting tool to get
all the code into PSR 2 format with ordered includes and shortened line
lengths.
