### PR TITLE
Implement a previous/next column for versioned models

### DIFF
--- a/src/Traits/Versioned.php
+++ b/src/Traits/Versioned.php
@@ -139,7 +139,6 @@ trait Versioned
                     $newVersion->{static::getVersionColumn()} = static::getNextVersion($this->{static::getModelIdColumn()});
                     $newVersion->{static::getIsCurrentVersionColumn()} = 1;
                     $newVersion->updated_at = $this->freshTimestamp();
-                    $newVersion->previous_id = $this->getAttributeFromArray('id');
 
                     // trigger the update event
                     if ($this->fireModelEvent('updating') === false) {
@@ -157,18 +156,14 @@ trait Versioned
 
                     if ($saved) {
 
-                        // toggle the is_current_version flag and set the
-                        // next_id column to the new models ID
+                        // toggle the is_current_version flag
                         $db->table((new static)->getTable())
                             ->where(static::getModelIdColumn(),
                                 $this->{static::getModelIdColumn()})
                             ->where(static::getIsCurrentVersionColumn(), 1)
                             ->where($this->primaryKey, '<>',
                                 $this->attributes[$this->primaryKey])
-                            ->update([
-                                static::getIsCurrentVersionColumn() => 0,
-                                'next_id' => $this->getAttributeFromArray('id'),
-                            ]);
+                            ->update([static::getIsCurrentVersionColumn() => 0]);
 
                         $this->fireModelEvent('updated', false);
                     }
@@ -345,7 +340,14 @@ trait Versioned
      */
     public function getPreviousModel()
     {
-        return $this->withOldVersions()->where('id', $this->previous_id)->first();
+        if ($this->version === 1) {
+            return null;
+        }
+
+        return $this->withOldVersions()
+            ->where('model_id', $this->model_id)
+            ->where('version', ($this->version - 1))
+            ->first();
     }
 
     /**
@@ -353,6 +355,13 @@ trait Versioned
      */
     public function getNextModel()
     {
-        return $this->withOldVersions()->where('id', $this->next_id)->first();
+        if ($this->is_current_version === true) {
+            return null;
+        }
+
+        return $this->withOldVersions()
+            ->where('model_id', $this->model_id)
+            ->where('version', ($this->version + 1))
+            ->first();
     }
 }

--- a/src/Traits/Versioned.php
+++ b/src/Traits/Versioned.php
@@ -339,4 +339,20 @@ trait Versioned
         return (new static)->newQueryWithoutScope(new VersioningScope)
             ->where(static::getQualifiedIsCurrentVersionColumn(), 0);
     }
+
+    /**
+     * @return mixed
+     */
+    public function getPreviousModel()
+    {
+        return $this->withOldVersions()->where('id', $this->previous_id)->first();
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getNextModel()
+    {
+        return $this->withOldVersions()->where('id', $this->next_id)->first();
+    }
 }

--- a/tests/FunctionalTestCase.php
+++ b/tests/FunctionalTestCase.php
@@ -34,8 +34,6 @@ class FunctionalTestCase extends \PHPUnit_Framework_TestCase
             $table->integer('is_current_version')->unsigned()->default(1);
             $table->integer('gadget_id')->unsigned()->default(0);
             $table->integer('doodad_id')->unsigned()->default(0);
-            $table->integer('previous_id')->unsigned()->nullable();
-            $table->integer('next_id')->unsigned()->nullable();
             $table->string('name');
             $table->timestamps();
         });
@@ -47,8 +45,6 @@ class FunctionalTestCase extends \PHPUnit_Framework_TestCase
             $table->integer('is_current_version')->unsigned()->default(1);
             $table->integer('widget_id')->unsigned()->default(0);
             $table->integer('doodad_id')->unsigned()->default(0);
-            $table->integer('previous_id')->unsigned()->nullable();
-            $table->integer('next_id')->unsigned()->nullable();
             $table->string('name');
             $table->timestamps();
         });
@@ -60,8 +56,6 @@ class FunctionalTestCase extends \PHPUnit_Framework_TestCase
             $table->integer('is_current_version')->unsigned()->default(1);
             $table->integer('gadget_id')->unsigned()->default(0);
             $table->integer('widget_id')->unsigned()->default(0);
-            $table->integer('previous_id')->unsigned()->nullable();
-            $table->integer('next_id')->unsigned()->nullable();
             $table->string('name');
             $table->timestamps();
         });

--- a/tests/FunctionalTestCase.php
+++ b/tests/FunctionalTestCase.php
@@ -34,6 +34,8 @@ class FunctionalTestCase extends \PHPUnit_Framework_TestCase
             $table->integer('is_current_version')->unsigned()->default(1);
             $table->integer('gadget_id')->unsigned()->default(0);
             $table->integer('doodad_id')->unsigned()->default(0);
+            $table->integer('previous_id')->unsigned()->nullable();
+            $table->integer('next_id')->unsigned()->nullable();
             $table->string('name');
             $table->timestamps();
         });
@@ -45,6 +47,8 @@ class FunctionalTestCase extends \PHPUnit_Framework_TestCase
             $table->integer('is_current_version')->unsigned()->default(1);
             $table->integer('widget_id')->unsigned()->default(0);
             $table->integer('doodad_id')->unsigned()->default(0);
+            $table->integer('previous_id')->unsigned()->nullable();
+            $table->integer('next_id')->unsigned()->nullable();
             $table->string('name');
             $table->timestamps();
         });
@@ -56,6 +60,8 @@ class FunctionalTestCase extends \PHPUnit_Framework_TestCase
             $table->integer('is_current_version')->unsigned()->default(1);
             $table->integer('gadget_id')->unsigned()->default(0);
             $table->integer('widget_id')->unsigned()->default(0);
+            $table->integer('previous_id')->unsigned()->nullable();
+            $table->integer('next_id')->unsigned()->nullable();
             $table->string('name');
             $table->timestamps();
         });

--- a/tests/VersionedTest.php
+++ b/tests/VersionedTest.php
@@ -52,6 +52,7 @@ class VersionedTest extends FunctionalTestCase
         $this->assertEquals('Updated ' . $data['name'], $model->name);
         $this->assertEquals(2, $model->version);
         $this->assertEquals(1, $model->is_current_version);
+        $this->assertEquals(1, $model->previous_id);
 
         // old model exists?
         $oldModel = $className::onlyOldVersions()->find(1);
@@ -66,6 +67,9 @@ class VersionedTest extends FunctionalTestCase
         // two records without scopes applied?
         $models = $className::withOldVersions()->get();
         $this->assertEquals(2, count($models));
+
+        // Original record has next_id set correctly
+        $this->assertEquals(2, $models->first()->next_id);
     }
 
     /**


### PR DESCRIPTION
This adds a next_id and previous_id column to versioned models that will store a link between saves. This should allow easier walking of the version history.

This is mostly a POC for the saving of the next/previous ID columns and to get any feedback about how it's implemented. There isn't any way to actually get the next/previous versions just yet.
