### PR TITLE
Support non-auto-incrementing models

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,6 +22,7 @@
   "require-dev": {
     "phpunit/phpunit": "4.6.*",
     "laravel/framework": "~5.0",
+    "ramsey/uuid": "~2.8",
     "orchestra/testbench": "~3.0"
   },
   "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,8 @@
   },
   "require-dev": {
     "phpunit/phpunit": "4.6.*",
-    "laravel/framework": "~5.0"
+    "laravel/framework": "~5.0",
+    "orchestra/testbench": "~3.0"
   },
   "autoload": {
     "psr-4": {

--- a/src/Traits/Versioned.php
+++ b/src/Traits/Versioned.php
@@ -136,6 +136,7 @@ trait Versioned
                         static::getVersionColumn(),
                         'updated_at'
                     ]);
+                    $newVersion->fireModelEvent('creating');
                     $newVersion->{static::getVersionColumn()} = static::getNextVersion($this->{static::getModelIdColumn()});
                     $newVersion->{static::getIsCurrentVersionColumn()} = 1;
                     $newVersion->updated_at = $this->freshTimestamp();
@@ -226,7 +227,7 @@ trait Versioned
         // are, as this attributes arrays must contain an "id" column already placed
         // there by the developer as the manually determined key for these models.
         else {
-            $query->insert($attributes);
+            self::create($attributes);
         }
 
         // We will go ahead and set the exists property to true, so that it is set when

--- a/src/Traits/Versioned.php
+++ b/src/Traits/Versioned.php
@@ -181,7 +181,9 @@ trait Versioned
         // ID attribute on the model to the value of the newly inserted row's ID
         // which is typically an auto-increment value managed by the database.
         else {
-            $this->{static::getModelIdColumn()} = static::getNextModelId();
+            if($this->{static::getModelIdColumn()} === null) {
+                $this->{static::getModelIdColumn()} = static::getNextModelId();
+            }
             $saved = $this->performInsert($query, $options);
         }
 

--- a/tests/FunctionalTestCase.php
+++ b/tests/FunctionalTestCase.php
@@ -1,12 +1,15 @@
 <?php namespace EloquentVersioned\Tests;
 
 use Illuminate\Database\Capsule\Manager as DBM;
+use Orchestra\Testbench\TestCase;
 
-class FunctionalTestCase extends \PHPUnit_Framework_TestCase
+class FunctionalTestCase extends TestCase
 {
 
     public function setUp()
     {
+        parent::setUp();
+
         $this->configureDatabase();
         $this->migrateTables();
     }

--- a/tests/FunctionalTestCase.php
+++ b/tests/FunctionalTestCase.php
@@ -62,5 +62,14 @@ class FunctionalTestCase extends TestCase
             $table->string('name');
             $table->timestamps();
         });
+
+        DBM::schema()->create('foos', function ($table) {
+            $table->string('id')->unique();
+            $table->string('model_id')->index();
+            $table->integer('version')->unsigned()->default(1);
+            $table->integer('is_current_version')->unsigned()->default(1);
+            $table->string('name');
+            $table->timestamps();
+        });
     }
 }

--- a/tests/Models/Foo.php
+++ b/tests/Models/Foo.php
@@ -26,4 +26,8 @@ class Foo extends BaseVersionedModel
     {
         return Uuid::uuid4();
     }
+
+    public static function getNextModelId() {
+        return Uuid::uuid4();
+    }
 }

--- a/tests/Models/Foo.php
+++ b/tests/Models/Foo.php
@@ -1,0 +1,29 @@
+<?php
+namespace EloquentVersioned\Tests\Models;
+
+use Rhumsaa\Uuid\Uuid;
+
+class Foo extends BaseVersionedModel
+{
+    protected $table = 'foos';
+
+    protected $fillable = ['*'];
+
+    public $incrementing = false;
+
+    protected static function boot()
+    {
+        parent::boot();
+
+        static::creating(function ($model) {
+            if (!array_key_exists($model->primaryKey, $model->attributes)) {
+                $model->attributes[$model->primaryKey] = $model->generateNewId();
+            }
+        });
+    }
+
+    public function generateNewId()
+    {
+        return Uuid::uuid4();
+    }
+}

--- a/tests/NonIncrementingVersionedTest.php
+++ b/tests/NonIncrementingVersionedTest.php
@@ -1,0 +1,131 @@
+<?php
+
+namespace EloquentVersioned\Tests;
+
+use Illuminate\Database\Eloquent\Model as Eloquent;
+
+class NonIncrementingVersionedTest extends FunctionalTestCase
+{
+    protected $modelPrefix = "\\EloquentVersioned\\Tests\\Models\\";
+
+    public function setUp()
+    {
+        parent::setUp();
+        Eloquent::unguard();
+        $this->resetEvents();
+    }
+
+    private function resetEvents()
+    {
+        // Define the models that have event listeners.
+        $models = [$this->modelPrefix . 'Foo'];
+
+        // Reset their event listeners.
+        foreach ($models as $model) {
+            // Flush any existing listeners.
+            call_user_func(array($model, 'flushEventListeners'));
+
+            // Reregister them.
+            call_user_func(array($model, 'boot'));
+        }
+    }
+
+    /**
+     * We should be able to create a model
+     *
+     * @param  array $data
+     *
+     * @dataProvider createDataProvider
+     */
+    public function testCreate($data)
+    {
+        $className = $this->modelPrefix . $data['name'];
+        $model = $className::create($data)->fresh();
+
+        // model exists?
+        $this->assertInstanceOf($this->modelPrefix . $data['name'], $model);
+        $this->assertEquals($data['model_id'], $model->id);
+        $this->assertEquals(1, $model->version);
+        $this->assertEquals(1, $model->is_current_version);
+    }
+
+    /**
+     * Using save() should create a new version
+     *
+     * @param  array $data
+     *
+     * @dataProvider createDataProvider
+     */
+    public function testSave($data)
+    {
+        $className = $this->modelPrefix . $data['name'];
+        $model = $className::create($data)->fresh();
+
+        $model->name = 'Updated ' . $data['name'];
+        $model->save();
+
+        // model was updated correctly?
+        $this->assertEquals($data['model_id'], $model->getOriginal('model_id'));
+        $this->assertEquals('Updated ' . $data['name'], $model->name);
+        $this->assertEquals(2, $model->version);
+        $this->assertEquals(1, $model->is_current_version);
+
+        // old model exists?
+        $oldModel = $className::onlyOldVersions()->where('id', $data['id'])->first();
+        $this->assertInstanceOf($this->modelPrefix . $data['name'], $oldModel);
+        $this->assertEquals(1, $oldModel->version);
+        $this->assertEquals(0, $oldModel->is_current_version);
+
+        // one record with scopes applied?
+        $models = $className::all();
+        $this->assertEquals(1, count($models));
+
+        // two records without scopes applied?
+        $models = $className::withOldVersions()->get();
+        $this->assertEquals(2, count($models));
+    }
+
+    /**
+     * Using saveMinor() should not create a new version
+     *
+     * @param  array $data
+     *
+     * @dataProvider createDataProvider
+     */
+    public function testMinorSave($data)
+    {
+        $className = $this->modelPrefix . $data['name'];
+        $model = $className::create($data)->fresh();
+
+        $model->name = 'Updated ' . $data['name'];
+        $model->saveMinor();
+
+        // model was updated correctly?
+        $this->assertEquals($data['model_id'], $model->id);
+        $this->assertEquals('Updated ' . $data['name'], $model->name);
+        $this->assertEquals(1, $model->version);
+        $this->assertEquals(1, $model->is_current_version);
+
+        // still only one record?
+        $models = $className::all();
+        $this->assertEquals(1, count($models));
+    }
+
+    /**
+     * Provides objects to use by tests
+     *
+     * @return array
+     */
+    public function createDataProvider()
+    {
+        return [
+            [
+                [
+                    'name' => 'Foo',
+                    'id' => 'b158f851-59aa-4d39-9f2b-969b5db8cfcd',
+                    'model_id' => '92a831eb-554c-4a15-9690-31f16a58b761',
+                ],
+            ],
+        ];
+    }
+}


### PR DESCRIPTION
This is a pull request for #8

There's a new model 'Foo' that uses UUIDs instead of an auto-incrementing integer column as its primary key. The few changes that need to be made a to make sure that the Laravel model events that a model has set up get fired when being created.

The addition of `orchestra/testbench` is to help with that (without it there's no dispatcher for the models). In the `NonIncrementingVersionedTest` file, the events need to be reset every for every test due to what seems like a bug in laravel/framework#1181.

The final change in `Versioned` is due to the testing and needing to be able to set a fixed `model_id` when creating a model that uses UUIDs. If one has been passed in when creating then it doesn't attempt to get a new `model_id`.
