### PR TITLE
Add travis.yml for automated testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,20 @@
+# Travis CI configuration
+
+language: php
+
+php:
+  - 5.5
+  - 5.6
+  - hhvm
+  - 7.0
+
+matrix:
+    allow_failures:
+        - php: 7.0
+        - php: hhvm
+
+install:
+  - composer install
+
+script:
+  - phpunit


### PR DESCRIPTION
Run PHPUnit on travis, e.g.

https://travis-ci.org/EspadaV8/eloquent-versioned

Testing on 5.5, 5.6, 7.0 and HHVM. 7.0 and HHVM have been set to allow failures since they're not set as supported versions just yet.
