### PR TITLE
Allow a model to set 'minor' attributes that won't create a new version

### DIFF
--- a/src/Traits/Versioned.php
+++ b/src/Traits/Versioned.php
@@ -7,6 +7,8 @@ use Illuminate\Database\Eloquent\Builder;
 trait Versioned
 {
 
+    protected $minorAttributes = [];
+
     protected $isVersioned = true;
 
     protected $hideVersioned = [
@@ -111,6 +113,10 @@ trait Versioned
      */
     public function save(array $options = array())
     {
+        if ($this->exists && $this->onlyHasMinorEdits()) {
+            return $this->saveMinor($options);
+        }
+
         $query = $this->newQueryWithoutScopes();
 
         $db = $this->getConnection();
@@ -333,5 +339,18 @@ trait Versioned
     {
         return (new static)->newQueryWithoutScope(new VersioningScope)
             ->where(static::getQualifiedIsCurrentVersionColumn(), 0);
+    }
+
+    public function onlyHasMinorEdits()
+    {
+        $changedAttributes = $this->getDirty();
+
+        foreach ($changedAttributes as $key => $value) {
+            if (!in_array($key, $this->minorAttributes)) {
+                return false;
+            }
+        }
+
+        return true;
     }
 }

--- a/tests/FunctionalTestCase.php
+++ b/tests/FunctionalTestCase.php
@@ -59,5 +59,15 @@ class FunctionalTestCase extends \PHPUnit_Framework_TestCase
             $table->string('name');
             $table->timestamps();
         });
+
+        DBM::schema()->create('bars', function ($table) {
+            $table->increments('id');
+            $table->integer('model_id')->unsigned()->default(1);
+            $table->integer('version')->unsigned()->default(1);
+            $table->integer('is_current_version')->unsigned()->default(1);
+            $table->string('name');
+            $table->string('title');
+            $table->timestamps();
+        });
     }
 }

--- a/tests/Models/Bar.php
+++ b/tests/Models/Bar.php
@@ -1,0 +1,13 @@
+<?php
+namespace EloquentVersioned\Tests\Models;
+
+class Bar extends BaseVersionedModel
+{
+    protected $minorAttributes = [
+        'name',
+    ];
+
+    protected $table = 'bars';
+
+    protected $fillable = ['*'];
+}

--- a/tests/VersionedTest.php
+++ b/tests/VersionedTest.php
@@ -95,6 +95,36 @@ class VersionedTest extends FunctionalTestCase
     }
 
     /**
+     * Making changes to fields marked as minor shouldn't create a new version
+     *
+     * @param  array $data
+     *
+     * @dataProvider createMinorEditsDataProvider
+     */
+    public function testMinorEdits($data)
+    {
+        $className = $this->modelPrefix . $data['name'];
+        $model = $className::create($data)->fresh();
+
+        $newName = 'Updated ' . $data['name'];
+        $model->name = $newName;
+        $model->save();
+
+        // was the model updated with a minor edit?
+        $this->assertEquals(1, $model->id);
+        $this->assertEquals($newName, $model->name);
+        $this->assertEquals(1, $model->version);
+
+        $newTitle = 'The New Bar';
+        $model->title = $newTitle;
+        $model->save();
+
+        // was the model updated with a major edit?
+        $this->assertEquals($newTitle, $model->title);
+        $this->assertEquals(2, $model->version);
+    }
+
+    /**
      * Provides objects to use by tests
      *
      * @return array
@@ -118,5 +148,22 @@ class VersionedTest extends FunctionalTestCase
             ),
             array(array('name' => 'Doodad', 'widget_id' => 1, 'gadget_id' => 1))
         );
+    }
+
+    /**
+     * Provides objects to use by tests
+     *
+     * @return array
+     */
+    public function createMinorEditsDataProvider()
+    {
+        return [
+            [
+                [
+                    'name' => 'Bar',
+                    'title' => 'The Bar',
+                ],
+            ],
+        ];
     }
 }


### PR DESCRIPTION
This adds a new property to models that allows them to give an array of attributes that should be counted as 'minor'. If a save is requested, the model exists and all the changed attributes are in the $minorAttributes array then only a minorSave will happen.

Fixes #2
