### PR TITLE
Provide a way to diff between to entity versions

### DIFF
--- a/src/Exceptions/IncompatibleModelMismatchException.php
+++ b/src/Exceptions/IncompatibleModelMismatchException.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace EloquentVersioned\Exceptions;
+
+use Exception;
+
+class IncompatibleModelMismatchException extends Exception
+{
+
+}

--- a/src/VersionDiffer.php
+++ b/src/VersionDiffer.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace EloquentVersioned;
+
+use Illuminate\Database\Eloquent\Model;
+
+class VersionDiffer
+{
+    private $ignoredFields = [
+        'is_current_version',
+        'version',
+        'created_at',
+        'updated_at',
+        'deleted_at',
+    ];
+
+    public function diff(Model $left, Model $right)
+    {
+        $changes = [];
+        $leftAttributes = array_except($left->getAttributes(), $this->ignoredFields);
+        $rightAttributes = array_except($right->getAttributes(), $this->ignoredFields);
+
+        $differences = array_diff($leftAttributes, $rightAttributes);
+
+        foreach ($differences as $key => $value) {
+            $changes[$key][0] = $leftAttributes[$key];
+            $changes[$key][1] = $rightAttributes[$key];
+            $changes[$key]['left'] = $leftAttributes[$key];
+            $changes[$key]['right'] = $rightAttributes[$key];
+        }
+
+        return $changes;
+    }
+}

--- a/src/VersionDiffer.php
+++ b/src/VersionDiffer.php
@@ -2,10 +2,12 @@
 
 namespace EloquentVersioned;
 
+use EloquentVersioned\Exceptions\IncompatibleModelMismatchException;
 use Illuminate\Database\Eloquent\Model;
 
 class VersionDiffer
 {
+
     private $ignoredFields = [
         'is_current_version',
         'version',
@@ -16,6 +18,10 @@ class VersionDiffer
 
     public function diff(Model $left, Model $right)
     {
+        if (($left instanceof $right) === false) {
+            throw new IncompatibleModelMismatchException;
+        }
+
         $changes = [];
         $leftAttributes = array_except($left->getAttributes(), $this->ignoredFields);
         $rightAttributes = array_except($right->getAttributes(), $this->ignoredFields);

--- a/tests/Models/UnusedModel.php
+++ b/tests/Models/UnusedModel.php
@@ -1,0 +1,7 @@
+<?php
+namespace EloquentVersioned\Tests\Models;
+
+class UnusedModel extends BaseVersionedModel
+{
+
+}

--- a/tests/VersionedTest.php
+++ b/tests/VersionedTest.php
@@ -1,5 +1,7 @@
 <?php namespace EloquentVersioned\Tests;
 
+use EloquentVersioned\Exceptions\IncompatibleModelMismatchException;
+use EloquentVersioned\Tests\Models\UnusedModel;
 use EloquentVersioned\VersionDiffer;
 use Illuminate\Database\Eloquent\Model as Eloquent;
 
@@ -125,6 +127,9 @@ class VersionedTest extends FunctionalTestCase
             ],
             $changes
         );
+
+        $this->setExpectedException(IncompatibleModelMismatchException::class);
+        (new VersionDiffer)->diff((new UnusedModel), (new $className));
     }
 
     /**


### PR DESCRIPTION
This is a WIP towards closing #4 

Currently there is a very simple class that takes 2 models and returns an array of any changed attributes between them. It doesn't check any versions in between. Example of returned array

``` php
array:1 [
  "name" => array:4 [
    "left" => "Widget"
    "right" => "Updated Widget"
    0 => "Widget"
    1 => "Updated Widget"
  ]
]
```

Currently a new instance of the VersionDiffer needs to be created, but this can probably come under a Facade or possibly just be changed into a static method.

Fields related to the versioning and timestamps are ignored (but this could be overridden with a 3rd parameter if you think it's needed `public function diff(Model $left, Model $right, array $ignore = [])`).

If the 2 models passed in aren't of the same type then an exception is thrown (I can't think of a reason that we would want to allow diffing between 2 different entities).
