### PR TITLE
Removing the requirement to guess next model ID

### DIFF
--- a/src/Traits/Versioned.php
+++ b/src/Traits/Versioned.php
@@ -176,12 +176,12 @@ trait Versioned
             }
         }
 
-        // If the model is brand new, we'll insert it into our database and set the
-        // ID attribute on the model to the value of the newly inserted row's ID
-        // which is typically an auto-increment value managed by the database.
+        // If the model is brand new, we'll insert it into our database, 
+        // then set the model_id to the id of the newly created record.
         else {
-            $this->{static::getModelIdColumn()} = static::getNextModelId();
             $saved = $this->performInsert($query, $options);
+            $this->{static::getModelIdColumn()} = $this->{$this->primaryKey};
+            $saved = $saved && $this->performUpdate($query, $options)
         }
 
         if ($saved) {
@@ -247,15 +247,6 @@ trait Versioned
         $this->isVersioned = $isVersioned;
 
         return $this;
-    }
-
-    /**
-     * @return mixed
-     */
-    public static function getNextModelId()
-    {
-        return (new static)->getConnection()->table((new static)->getTable())
-            ->max(static::getModelIdColumn()) + 1;
     }
 
     /**


### PR DESCRIPTION
By using an extra SQL query to save then update, the versioned model_id can be reliably resolved.
This removes the potential incorrect IDs used caused by a race condition of multiple concurrent saves, as well as incorrect IDs being guessed by deleting records off the end of the table.

p.s. my first PR. Hopefully everything is in order.
Feedback welcome :)
