### PR TITLE
Remove the correct index for a binded value

### DIFF
--- a/src/Scopes/VersioningScope.php
+++ b/src/Scopes/VersioningScope.php
@@ -31,7 +31,7 @@ class VersioningScope implements ScopeInterface
             }
             if ($value['column'] == $column) {
                 if ($bindings[$bindKey - 1] == 1) {
-                    unset($bindings[$key]);
+                    unset($bindings[$bindKey - 1]);
                 }
                 unset($query->wheres[$key]);
             }


### PR DESCRIPTION
When trying to get old versions the unbinding would try to remove the incorrect key.
