### PR TITLE
this commit fixes #22

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ $project->saveMinor(); // doesn't create a new version
 If you want to retrieve a list of all versions of a model (or include old versions in a bigger query):
 
 ```php
-$projectVersions = Project::withOldVersions()->find(1);
+$projectVersions = Project::withOldVersions()->findAll(1);
 ```
 
 If run after our example above, this would return an array with 2 models.
@@ -177,7 +177,7 @@ If run after our example above, this would return an array with 2 models.
 You can also retrieve a list of *only* old models by using:
 
 ```php
-$oldVersions = Project::onlyOldVersions()->find(1);
+$oldVersions = Project::onlyOldVersions()->findAll(1);
 ```
 
 Otherwise, the rest of Eloquent's ORM operations should work as usual, including the out-of-the-box relations.

--- a/src/Traits/Versioned.php
+++ b/src/Traits/Versioned.php
@@ -46,11 +46,13 @@ trait Versioned
      */
 
     /**
+     * Get the table qualified key name.
+     *
      * @return string
      */
-    public function getKeyName()
+    public function getQualifiedKeyName()
     {
-        return $this->isVersioned ? $this->getModelIdColumn() : $this->primaryKey;
+        return $this->getQualifiedModelIdColumn();
     }
 
     /**


### PR DESCRIPTION
I modified the README as well because the examples said to use find (which always limits to 1 result)... 

Also to fix the issue I realized the update query was always grabbing the model_id column for the where clause.  This didn't work because the value in the database was always 1 and the model_id on the object would already be updated to be the same as the new id.

In order to fix this I removed the getKeyName override in the Versioned Trait.  

Doing this fixed most issues however I noticed that it broke the withOldVersions scope that is included in the trait.  I fixed this by updating the reference to the QualifiedKeyName by using the qualifiedModelIdColumn.  I've tested the various methods in the package and this seems to fix everything...

I didn't see the purpose of using the isVersioned check on the new override, since any object using this trait we would assume is being versioned.  Right?  is there some reason that should be included?
